### PR TITLE
#28 tabbing acceleration

### DIFF
--- a/components/circular_progress.py
+++ b/components/circular_progress.py
@@ -24,7 +24,8 @@ class CircularProgressbar(object):
                                                 font=self.custom_font)
 
     def set(self, value):
-        self.extent = value
+        self.extent = value if isinstance(value, int) else 0
         self.canvas.itemconfigure(self.arc_id, extent=((self.extent / 100) * self.full_extent))
         # Update percentage value displayed.
-        self.canvas.itemconfigure(self.label_id, text=self.extent)
+        self.percent = value if isinstance(value, int) else "N/A"
+        self.canvas.itemconfigure(self.label_id, text=self.percent)

--- a/models/model.py
+++ b/models/model.py
@@ -10,6 +10,9 @@ class Model:
         self.pack_temp_data: List[Optional[int]] = []
         self.page_height = 570
         self.page_width = 1024
+        self.debounce_max_value = 125
+        self.up_debounce_max_value = 125
+        self.down_debounce_max_value = 125
         pass
 
     def check_can(self) -> None:
@@ -74,7 +77,7 @@ class Model:
     
     def get_MPU_fault(self) -> Optional[int]:
         pass
-    
+
     def get_by_id(self, id: int) -> Optional[int]:
         return self.current_data[id]
 

--- a/models/model.py
+++ b/models/model.py
@@ -10,9 +10,6 @@ class Model:
         self.pack_temp_data: List[Optional[int]] = []
         self.page_height = 570
         self.page_width = 1024
-        self.debounce_max_value = 125
-        self.up_debounce_max_value = 125
-        self.down_debounce_max_value = 125
         pass
 
     def check_can(self) -> None:

--- a/nero_view.py
+++ b/nero_view.py
@@ -40,7 +40,6 @@ class NeroView(customtkinter.CTk):
         self.debounce_down_value = 0
         self.debounce_left_value = 0
         self.debounce_right_value = 0
-        self.debounce_max_value = 125
 
         # configure window
         self.title("NERO")
@@ -127,7 +126,7 @@ class NeroView(customtkinter.CTk):
     def update_right_button_pressed(self):
         value = self.model.get_right_button_pressed()
         if value is not None and int(value) == 1 and self.debounce_right_value == 0:
-            self.debounce_right_value = self.debounce_max_value
+            self.debounce_right_value = self.model.debounce_max_value
             self.current_screen.right_button_pressed()
         elif value is not None and int(value) == 0:
             self.debounce_right_value = 0
@@ -137,7 +136,7 @@ class NeroView(customtkinter.CTk):
     def update_debug_pressed(self):
         value = self.model.get_debug_pressed()
         if value is not None and int(value) == 1 and self.debounce_left_value == 0:
-            self.debounce_left_value = self.debounce_max_value
+            self.debounce_left_value = self.model.debounce_max_value
             self.is_debug = not self.is_debug
         elif value is not None and int(value) == 0:
             self.debounce_left_value = 0
@@ -148,9 +147,11 @@ class NeroView(customtkinter.CTk):
         value = self.model.get_up_button_pressed()
         if value is not None and int(value) == 1 and self.debounce_up_value == 0:
             self.current_screen.up_button_pressed()
-            self.debounce_up_value = self.debounce_max_value
+            self.debounce_up_value = self.model.up_debounce_max_value
+            self.model.up_debounce_max_value -= 5 if self.model.up_debounce_max_value - 5 > 1 else 0
         elif value is not None and int(value) == 0:
             self.debounce_up_value = 0
+            self.model.up_debounce_max_value = 125
         else:
             self.debounce_up_value -= 1
 
@@ -158,9 +159,11 @@ class NeroView(customtkinter.CTk):
         value = self.model.get_down_button_pressed()
         if value is not None and int(value) == 1 and self.debounce_down_value == 0:
             self.current_screen.down_button_pressed()
-            self.debounce_down_value = self.debounce_max_value
+            self.debounce_down_value = self.model.down_debounce_max_value
+            self.model.down_debounce_max_value -= 5 if self.model.down_debounce_max_value - 5 > 1 else 0
         elif value is not None and int(value) == 0:
             self.debounce_down_value = 0
+            self.model.down_debounce_max_value = 125
         else:
             self.debounce_down_value -= 1
 
@@ -168,7 +171,7 @@ class NeroView(customtkinter.CTk):
         value = self.model.get_enter_button_pressed()
         if value is not None and int(value) == 1 and self.debounce_enter_value == 0:
             self.current_screen.enter_button_pressed()
-            self.debounce_enter_value = self.debounce_max_value
+            self.debounce_enter_value = self.model.debounce_max_value
         elif value is not None and int(value) == 0:
             self.debounce_enter_value = 0
         else:

--- a/nero_view.py
+++ b/nero_view.py
@@ -148,7 +148,7 @@ class NeroView(customtkinter.CTk):
         if value is not None and int(value) == 1 and self.debounce_up_value == 0:
             self.current_screen.up_button_pressed()
             self.debounce_up_value = self.model.up_debounce_max_value
-            self.model.up_debounce_max_value -= 5 if self.model.up_debounce_max_value - 5 > 1 else 0
+            self.model.up_debounce_max_value -= 5 if self.model.up_debounce_max_value - 5 > 40 else 0
         elif value is not None and int(value) == 0:
             self.debounce_up_value = 0
             self.model.up_debounce_max_value = 125
@@ -160,7 +160,7 @@ class NeroView(customtkinter.CTk):
         if value is not None and int(value) == 1 and self.debounce_down_value == 0:
             self.current_screen.down_button_pressed()
             self.debounce_down_value = self.model.down_debounce_max_value
-            self.model.down_debounce_max_value -= 5 if self.model.down_debounce_max_value - 5 > 1 else 0
+            self.model.down_debounce_max_value -= 5 if self.model.down_debounce_max_value - 5 > 40 else 0
         elif value is not None and int(value) == 0:
             self.debounce_down_value = 0
             self.model.down_debounce_max_value = 125

--- a/nero_view.py
+++ b/nero_view.py
@@ -41,6 +41,10 @@ class NeroView(customtkinter.CTk):
         self.debounce_left_value = 0
         self.debounce_right_value = 0
 
+        self.debounce_max_value = 125
+        self.up_debounce_max_value = 125
+        self.down_debounce_max_value = 125
+
         # configure window
         self.title("NERO")
         self.grid_rowconfigure(1, weight=1, minsize=self.model.page_height)
@@ -126,7 +130,7 @@ class NeroView(customtkinter.CTk):
     def update_right_button_pressed(self):
         value = self.model.get_right_button_pressed()
         if value is not None and int(value) == 1 and self.debounce_right_value == 0:
-            self.debounce_right_value = self.model.debounce_max_value
+            self.debounce_right_value = self.debounce_max_value
             self.current_screen.right_button_pressed()
         elif value is not None and int(value) == 0:
             self.debounce_right_value = 0
@@ -136,7 +140,7 @@ class NeroView(customtkinter.CTk):
     def update_debug_pressed(self):
         value = self.model.get_debug_pressed()
         if value is not None and int(value) == 1 and self.debounce_left_value == 0:
-            self.debounce_left_value = self.model.debounce_max_value
+            self.debounce_left_value = self.debounce_max_value
             self.is_debug = not self.is_debug
         elif value is not None and int(value) == 0:
             self.debounce_left_value = 0
@@ -147,11 +151,11 @@ class NeroView(customtkinter.CTk):
         value = self.model.get_up_button_pressed()
         if value is not None and int(value) == 1 and self.debounce_up_value == 0:
             self.current_screen.up_button_pressed()
-            self.debounce_up_value = self.model.up_debounce_max_value
-            self.model.up_debounce_max_value -= 5 if self.model.up_debounce_max_value - 5 > 40 else 0
+            self.debounce_up_value = self.up_debounce_max_value
+            self.up_debounce_max_value -= 5 if self.up_debounce_max_value - 5 > 40 else 0
         elif value is not None and int(value) == 0:
             self.debounce_up_value = 0
-            self.model.up_debounce_max_value = 125
+            self.up_debounce_max_value = 125
         else:
             self.debounce_up_value -= 1
 
@@ -159,11 +163,11 @@ class NeroView(customtkinter.CTk):
         value = self.model.get_down_button_pressed()
         if value is not None and int(value) == 1 and self.debounce_down_value == 0:
             self.current_screen.down_button_pressed()
-            self.debounce_down_value = self.model.down_debounce_max_value
-            self.model.down_debounce_max_value -= 5 if self.model.down_debounce_max_value - 5 > 40 else 0
+            self.debounce_down_value = self.down_debounce_max_value
+            self.down_debounce_max_value -= 5 if self.down_debounce_max_value - 5 > 40 else 0
         elif value is not None and int(value) == 0:
             self.debounce_down_value = 0
-            self.model.down_debounce_max_value = 125
+            self.down_debounce_max_value = 125
         else:
             self.debounce_down_value -= 1
 
@@ -171,7 +175,7 @@ class NeroView(customtkinter.CTk):
         value = self.model.get_enter_button_pressed()
         if value is not None and int(value) == 1 and self.debounce_enter_value == 0:
             self.current_screen.enter_button_pressed()
-            self.debounce_enter_value = self.model.debounce_max_value
+            self.debounce_enter_value = self.debounce_max_value
         elif value is not None and int(value) == 0:
             self.debounce_enter_value = 0
         else:


### PR DESCRIPTION
## Changes

made seperate debounces for up and down button presses so that if you hold it consecutively the debounce will decrease to a minimum of 40 ms. 

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #28  (issue #)
